### PR TITLE
Remove SSH and Ant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set
 
 # Update packages
 RUN apt-get -y update && \
-    apt-get -y install software-properties-common bzip2 ssh net-tools openssh-server socat curl && \
+    apt-get -y install software-properties-common bzip2 net-tools socat curl && \
     add-apt-repository ppa:webupd8team/java && \
     apt-get update && \
     apt-get -y install oracle-java7-installer && \
@@ -32,11 +32,6 @@ RUN wget -qO- http://dl.google.com/android/android-sdk_r23-linux.tgz | \
     tar xvz -C /usr/local/ && \
     mv /usr/local/android-sdk-linux /usr/local/android-sdk && \
     chown -R root:root /usr/local/android-sdk/
-
-# Install apache ant
-RUN wget -qO- http://archive.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.gz | \
-    tar xvz -C /usr/local && \
-    mv /usr/local/apache-ant-1.8.4 /usr/local/apache-ant
 
 # Add android tools and platform tools to PATH
 ENV ANDROID_HOME /usr/local/android-sdk
@@ -58,15 +53,6 @@ RUN ( sleep 4 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --
 # Create fake keymap file
 RUN mkdir /usr/local/android-sdk/tools/keymaps && \
     touch /usr/local/android-sdk/tools/keymaps/en-us
-
-# Run sshd
-RUN mkdir /var/run/sshd && \
-    echo "root:$ROOTPASSWORD" | chpasswd && \
-    sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
-    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
-    echo "export VISIBLE=now" >> /etc/profile
-
-ENV NOTVISIBLE "in users profile"
 
 # Add entrypoint
 ADD entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,8 +15,6 @@ if [[ -n $1 ]]; then
     tail -1 $1
 fi
 
-# Run sshd
-/usr/sbin/sshd
 adb start-server
 
 # Detect ip and forward ADB ports outside to outside interface


### PR DESCRIPTION
Hi again @tracer0tong,

this PR is just a proposal as I don't exactly know what requirements you have for the emulator.
I removed the SSH stuff, because for me the ability to `docker exec` into the container is sufficient in most cases.
Also, Ant is not per se required for an image that just hosts an Android emulator.
Do you in a later step build something inside the android-emulator container?

In both cases, would it be an option to just inherit from this image and install Ant and SSH in the inherited image? That would make the android-emulator image itself smaller and more secure.

If you're Ok with removing Ant, but not SSH or the other way round, I can also create a PR that does just this.

Best
  Martin
